### PR TITLE
Change struct separator to align with JavaScript

### DIFF
--- a/.cfformat.json
+++ b/.cfformat.json
@@ -50,7 +50,7 @@
 	"parentheses.padding": true,
 	"strings.quote": "double",
 	"strings.attributes.quote": "double",
-	"struct.separator": " : ",
+	"struct.separator": ": ",
 	"struct.padding": true,
 	"struct.empty_padding": false,
 	"struct.multiline.leading_comma": false,


### PR DESCRIPTION
To me, the benefit of using a colon (`:`) as a struct separator is it makes the JavaScript interop easier.  The default formatting of objects in popular JavaScript formatters is `{ key: value }`. (In fact, there is [no option to change this](https://prettier.io/docs/en/options.html) in Prettier.)  I propose we follow that standard.